### PR TITLE
Refactored the client implementation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,17 +12,12 @@ specificaties met GEMMA-zaken componenten communiceert.
 Features
 ========
 
-* Ophalen van OAS 3.0 spec
+* Ophalen van OAS 3.0 spec & caching
 * Aanmaken van resources volgens specificatie
 * Generieke opzet, maar specifiek gebruik in de zaakgericht-werken services
 * Introspectie in het OAS schema: lees op basis van een resource URL uit wat
   er precies hoort achter deze URL te zitten.
 * ZDS autorisatiemodel via JWT out-of-the-box ondersteund.
-
-Geplande features
------------------
-
-* Ophalen OAS 3.0 spec zonder conversie
 
 Installatie
 ===========
@@ -47,7 +42,7 @@ Initialiseren (statische configuratie)
 --------------------------------------
 
 De client moet geinitialiseerd worden met de locatie van de componenten. Dit
-doe je eenmalig:
+kan eenmalig of just-in-time wanneer je de client nodig hebt:
 
 .. code-block:: bash
 
@@ -125,19 +120,19 @@ URL.
 
     from zds_client import Client
 
-    client = Client.from_url('https://api.nl/v1/resource/123', base_dir='/path/to/node_modules')
+    client = Client.from_url('https://api.nl/v1/resource/123')
 
-.. note::
-   Momenteel moet je nog het pad naar `node_modules` opgeven waar de
-   `swagger2openapi` beschikbaar is om on the fly conversie van OAS 2.0 naar
-   OAS 3.0 te doen. Deze moet dus in je eigen project beschikbaar zijn.
+Indien authorisatie hierop nodig is, kan je deze zelf assignen:
 
-   Er zijn plannen om dit uit de client te slopen, en af te dwingen dat de
-   server MOET OAS 3.0 serveren. Dit betekent dat dan OAS 2.0 support
-   gedropped wordt.
+.. code-block:: python
 
-.. note::
-   Deze workflow ondersteund momenteel nog geen AUTH.
+    from zds_client import ClientAuth
+
+    client.auth = ClientAuth(
+        client_id='my-client-id',
+        secret='my-client-secret',
+        **claims
+    )
 
 Resources manipuleren
 ---------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 # see http://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files
 [metadata]
 name = gemma-zds-client
-version = 0.8.1
+version = 0.9.0.dev0
 description = Generieke client voor GEMMA-zaken componenten
 long_description = file: README.rst
 url = https://github.com/VNG-Realisatie/gemma-zds-client

--- a/zds_client/client.py
+++ b/zds_client/client.py
@@ -256,16 +256,19 @@ class Client:
         url = get_operation_url(self.schema, operation_id, **path_kwargs)
         return self.request(url, operation_id, method='POST', json=data, expected_status=201)
 
-    def update(self, resource: str, data: dict, **path_kwargs) -> Object:
+    def update(self, resource: str, data: dict, url=None, **path_kwargs) -> Object:
         operation_id = '{resource}_update'.format(resource=resource)
-        url = get_operation_url(self.schema, operation_id, **path_kwargs)
+        if url is None:
+            url = get_operation_url(self.schema, operation_id, **path_kwargs)
         return self.request(url, operation_id, method='PUT', json=data, expected_status=200)
 
-    def partial_update(self, resource: str, data: dict, **path_kwargs) -> Object:
+    def partial_update(self, resource: str, data: dict, url=None, **path_kwargs) -> Object:
         operation_id = '{resource}_partial_update'.format(resource=resource)
-        url = get_operation_url(self.schema, operation_id, **path_kwargs)
+        if url is None:
+            url = get_operation_url(self.schema, operation_id, **path_kwargs)
         return self.request(url, operation_id, method='PATCH', json=data, expected_status=200)
 
-    def operation(self, operation_id: str, data: dict, **path_kwargs) -> Union[List[Object], Object]:
-        url = get_operation_url(self.schema, operation_id, **path_kwargs)
+    def operation(self, operation_id: str, data: dict, url=None, **path_kwargs) -> Union[List[Object], Object]:
+        if url is None:
+            url = get_operation_url(self.schema, operation_id, **path_kwargs)
         return self.request(url, operation_id, method='POST', json=data)

--- a/zds_client/config.py
+++ b/zds_client/config.py
@@ -1,0 +1,55 @@
+from urllib.parse import urlparse
+
+from .auth import ClientAuth
+
+default_ports = {
+    'https': 443,
+    'http': 80,
+}
+
+
+class ClientConfig:
+    def __init__(self, scheme: str='https', host: str='localhost', port: int=None, auth: ClientAuth=None):
+        self.scheme = scheme
+        self.host = host
+        self.port = port if port else default_ports[scheme]
+        self.auth = auth
+
+    def __repr__(self):
+        return "<%s: %s>" % (self.__class__.__name__, self.base_url)
+
+    @classmethod
+    def from_dict(cls, _config: dict) -> 'ClientConfig':
+        _auth = _config.pop('auth', None)
+        auth = None if not _auth else ClientAuth(**_auth)
+        return cls(**_config, auth=auth)
+
+    @classmethod
+    def from_url(cls, detail_url: str) -> 'ClientConfig':
+        parsed_url = urlparse(detail_url)
+
+        if ':' in parsed_url.netloc:
+            host, port = parsed_url.netloc.split(':')
+        else:
+            host, port = parsed_url.netloc, None
+
+        # register the config
+        return cls.from_dict({
+            'scheme': parsed_url.scheme,
+            'host': host,
+            'port': port,
+        })
+
+    @property
+    def base_url(self) -> str:
+        """
+        Calculate the base URL, without the api root base path.
+        """
+        base = f"{self.scheme}://{self.host}"
+
+        # if it's the default ports, we don't need to be explicit
+        default_port = default_ports[self.scheme]
+        if self.port == default_port:
+            return base
+
+        return f"{base}:{self.port}"

--- a/zds_client/oas.py
+++ b/zds_client/oas.py
@@ -1,0 +1,53 @@
+"""
+Manage OpenAPI Specification 3.0.x schemas.
+"""
+import requests
+import yaml
+
+__all__ = ['schema_fetcher']
+
+
+class SchemaFetcher:
+    """
+    Retrieve and cache OpenAPI Specification schemas
+
+    Caching is done based on the URL of the schema. The schema is parsed from
+    YAML and the resulting dictionary is returned/stored.
+    """
+
+    def __init__(self):
+        self.cache = {}
+
+    def fetch(self, url: str, *args, **kwargs) -> dict:
+        """
+        Fetch a YAML-based OAS 3.0.x schema.
+
+        Any extra arguments or keyword arguments are forwarded to
+        :func:`requests.get`.
+
+        :param url: The URL to the schema, must point to a YAML object
+        :raises: :class:`requests.RequestException` if the URL doesn't properly
+          resolve
+        :raises: :class:`ValueError` if the API-spec is not a OAS 3.0.x spec
+        """
+        if url in self.cache:
+            return self.cache[url]
+
+        response = requests.get(url, *args, **kwargs)
+        response.raise_for_status()
+
+        spec = yaml.safe_load(response.content)
+        spec_version = response.headers.get(
+            'X-OAS-Version',
+            spec.get('openapi', spec.get('swagger', ''))
+        )
+        if not spec_version.startswith('3.0'):
+            raise ValueError("Unsupported spec version: {}".format(spec_version))
+
+        self.cache[url] = spec
+
+        return spec
+
+
+# sentinel instance, with a cache
+schema_fetcher = SchemaFetcher()

--- a/zds_client/registry.py
+++ b/zds_client/registry.py
@@ -1,0 +1,29 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class ClientRegistry:
+
+    def __init__(self):
+        self._registry = {}
+
+    def __getitem__(self, key):
+        return self._registry[key]
+
+    def __delitem__(self, key):
+        del self._registry[key]
+
+    def __setitem__(self, key, value):
+        if key in self._registry:
+            logger.debug("Overwriting config for '%s'", key)
+        self._registry[key] = value
+
+    def __contains__(self, key):
+        return key in self._registry
+
+    def register(self, alias: str, config: dict):
+        self._registry[alias] = config
+
+
+registry = ClientRegistry()


### PR DESCRIPTION
This refactor was long overdue by now...

* easier to test
* no annoying globals-like behaviour making it awkward to get the client configured
* (better) caching of OAS-retrieval
* separation of concerns in the code
* should be easier to introspect