### PR TITLE
operation id suffix mapping

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -124,7 +124,7 @@ URL.
 
     client = Client.from_url('https://api.nl/v1/resource/123')
 
-Indien authorisatie hierop nodig is, kan je deze zelf assignen:
+Indien autorisatie hierop nodig is, kan je deze zelf assignen:
 
 .. code-block:: python
 
@@ -133,7 +133,6 @@ Indien authorisatie hierop nodig is, kan je deze zelf assignen:
     client.auth = ClientAuth(
         client_id='my-client-id',
         secret='my-client-secret',
-        **claims
     )
 
 Resources manipuleren
@@ -160,6 +159,24 @@ manipuleren:
         'bronorganisatie': '000000000',
         'zaaktype': 'http://localhost:8002/api/v1/zaaktypen/<uuid>'
     })
+
+**Operation suffixes**
+
+De ``operation_id`` van de OAS-operations staan centraal - op basis hiervan wordt de
+URL + HTTP method opgehaald die nodig is voor de call. Je kan deze suffixes overriden
+in client subclasses:
+
+.. code-block:: python
+
+    class MyClient(Client):
+        operation_suffix_mapping = {
+            "list": "List",
+            "retrieve": "Retrieve",
+            "create": "Create",
+            "update": "Update",
+            "partial_update": "PartialUpdate",
+            "delete": "Delete",
+        }
 
 
 Schema introspectie
@@ -214,9 +231,8 @@ Install using:
 This will pull in the extra dependencies. Make sure to follow the `nlx-url-rewriter`_
 setup instructions.
 
-
-.. |build-status| image:: https://travis-ci.org/VNG-Realisatie/gemma-zds-client.svg?branch=master
+.. |build-status| image:: https://github.com/VNG-Realisatie/gemma-zds-client/workflows/Run%20CI/badge.svg
     :alt: Build status
-    :target: https://travis-ci.org/VNG-Realisatie/gemma-zds-client
+    :target: https://github.com/VNG-Realisatie/gemma-zds-client/actions?query=workflow%3A%22Run+CI%22
 
 .. _nlx-url-rewriter: https://pypi.org/project/nlx-url-rewriter/

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,14 +11,15 @@ author = Maykin Media, VNG-Realisatie
 author_email = support@maykinmedia.nl
 keywords = openapi, swagger, django, vng, client, requests
 classifiers =
-    Development Status :: 3 - Alpha
+    Development Status :: 4 - Beta
     Intended Audience :: Developers
     Operating System :: Unix
     Operating System :: MacOS
     Operating System :: Microsoft :: Windows
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Topic :: Software Development :: Libraries :: Python Modules
 
 [options]
@@ -67,20 +68,16 @@ release =
 [aliases]
 test=pytest
 
-[bdist_wheel]
-universal = 1
-
 [isort]
 combine_as_imports = true
 default_section = THIRDPARTY
-include_trailing_comma = false
-line_length = 79
-multi_line_output = 5
+include_trailing_comma = true
+line_length = 88
+multi_line_output = 3
 skip = env,.tox,.history,.eggs
-; skip_glob =
-not_skip = __init__.py
-known_first_party=zds_client
-sections=FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+known_first_party = zds_client
+sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+ensure_newline_before_comments = true
 
 [tool:pytest]
 testpaths = tests

--- a/zds_client/client.py
+++ b/zds_client/client.py
@@ -119,6 +119,15 @@ class Client:
 
     auth = None
 
+    operation_suffix_mapping = {
+        "list": "_list",
+        "retrieve": "_read",
+        "create": "_create",
+        "update": "_update",
+        "partial_update": "_partial_update",
+        "delete": "_delete",
+    }
+
     def __init__(self, service: str, base_path: str = "/api/v1/"):
         # pull out the config, so that we should be thread safe
         try:
@@ -164,9 +173,6 @@ class Client:
               auth:
                 client_id: some-client-id
                 secret: very-secret
-                scopes:
-                  - scope1
-                  - scope2
 
         Multiple service configs are supported, each with their own alias.
         The `port` and `auth` keys are optional. Port will default to 80 or
@@ -252,7 +258,7 @@ class Client:
         method="GET",
         expected_status=200,
         request_kwargs: Optional[dict] = None,
-        **kwargs
+        **kwargs,
     ) -> Union[List[Object], Object]:
         """
         Make the HTTP request using requests.
@@ -328,9 +334,10 @@ class Client:
         resource: str,
         query_params=None,
         request_kwargs: Optional[dict] = None,
-        **path_kwargs
+        **path_kwargs,
     ) -> List[Object]:
-        operation_id = "{resource}_list".format(resource=resource)
+        op_suffix = self.operation_suffix_mapping["list"]
+        operation_id = f"{resource}{op_suffix}"
         url = get_operation_url(
             self.schema, operation_id, base_url=self.base_url, **path_kwargs
         )
@@ -343,9 +350,10 @@ class Client:
         resource: str,
         url=None,
         request_kwargs: Optional[dict] = None,
-        **path_kwargs
+        **path_kwargs,
     ) -> Object:
-        operation_id = "{resource}_read".format(resource=resource)
+        op_suffix = self.operation_suffix_mapping["retrieve"]
+        operation_id = f"{resource}{op_suffix}"
         if url is None:
             url = get_operation_url(
                 self.schema, operation_id, base_url=self.base_url, **path_kwargs
@@ -357,9 +365,10 @@ class Client:
         resource: str,
         data: dict,
         request_kwargs: Optional[dict] = None,
-        **path_kwargs
+        **path_kwargs,
     ) -> Object:
-        operation_id = "{resource}_create".format(resource=resource)
+        op_suffix = self.operation_suffix_mapping["create"]
+        operation_id = f"{resource}{op_suffix}"
         url = get_operation_url(
             self.schema, operation_id, base_url=self.base_url, **path_kwargs
         )
@@ -378,9 +387,10 @@ class Client:
         data: dict,
         url=None,
         request_kwargs: Optional[dict] = None,
-        **path_kwargs
+        **path_kwargs,
     ) -> Object:
-        operation_id = "{resource}_update".format(resource=resource)
+        op_suffix = self.operation_suffix_mapping["update"]
+        operation_id = f"{resource}{op_suffix}"
         if url is None:
             url = get_operation_url(
                 self.schema, operation_id, base_url=self.base_url, **path_kwargs
@@ -400,9 +410,10 @@ class Client:
         data: dict,
         url=None,
         request_kwargs: Optional[dict] = None,
-        **path_kwargs
+        **path_kwargs,
     ) -> Object:
-        operation_id = "{resource}_partial_update".format(resource=resource)
+        op_suffix = self.operation_suffix_mapping["partial_update"]
+        operation_id = f"{resource}{op_suffix}"
         if url is None:
             url = get_operation_url(
                 self.schema, operation_id, base_url=self.base_url, **path_kwargs
@@ -421,9 +432,10 @@ class Client:
         resource: str,
         url=None,
         request_kwargs: Optional[dict] = None,
-        **path_kwargs
+        **path_kwargs,
     ) -> Object:
-        operation_id = "{resource}_delete".format(resource=resource)
+        op_suffix = self.operation_suffix_mapping["delete"]
+        operation_id = f"{resource}{op_suffix}"
         if url is None:
             url = get_operation_url(
                 self.schema, operation_id, base_url=self.base_url, **path_kwargs
@@ -440,14 +452,15 @@ class Client:
         self,
         operation_id: str,
         data: dict,
+        method="POST",
         url=None,
         request_kwargs: Optional[dict] = None,
-        **path_kwargs
+        **path_kwargs,
     ) -> Union[List[Object], Object]:
         if url is None:
             url = get_operation_url(
                 self.schema, operation_id, base_url=self.base_url, **path_kwargs
             )
         return self.request(
-            url, operation_id, method="POST", json=data, request_kwargs=request_kwargs
+            url, operation_id, method=method, json=data, request_kwargs=request_kwargs
         )


### PR DESCRIPTION
When dealing with some external API schema's, they don't always follow the operation ID naming pattern as used by the API's voor Zaakgericht werken.

This feature adds the ability to customize this mapping, so that we can keep using the convience client methods `retrieve`, `create` etc. without having to build URLs manually.