### PR TITLE
Add `status_code` attribute to `ClientError`

### DIFF
--- a/zds_client/client.py
+++ b/zds_client/client.py
@@ -26,7 +26,9 @@ UUID_PATTERN = re.compile(
 
 
 class ClientError(Exception):
-    pass
+    def __init__(self, message, status_code: int) -> None:
+        super().__init__(message)
+        self.status_code = status_code
 
 
 class Client:
@@ -234,7 +236,7 @@ class Client:
         except requests.HTTPError as exc:
             if response.status_code >= 500:
                 raise
-            raise ClientError(response_json) from exc
+            raise ClientError(response_json, status_code=response.status_code) from exc
 
         assert response.status_code == expected_status, response_json
         return response_json


### PR DESCRIPTION
To handle exceptions on open-objects, I need to get the correct status code when an [exception is raised](https://github.com/VNG-Realisatie/gemma-zds-client/blob/master/zds_client/client.py#L237) in the client class.

As the `ClientError` exception is raised from the `requests.HTTPError`, I'm still able to get the status code this way:

```py
try:
    object = client.retrieve(...)
except ClientError as err:
    print(err.__cause__.response.status_code)
```

But it would be great to have it accessible on the ClientError instead (or we could use the whole response as well, instead of just the status code).